### PR TITLE
Allow Symfony 3 and use caret operator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,17 +12,18 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.9",
-        "symfony-cmf/resource": "~1.0"
+        "symfony/framework-bundle": "^2.3|3.*",
+        "symfony-cmf/resource": "^1.0"
     },
     "require-dev": {
-        "symfony-cmf/testing": "~1.1",
-        "phpspec/prophecy-phpunit": "~1.0.0",
+        "symfony-cmf/testing": "^1.3",
+        "phpspec/prophecy-phpunit": "^1.0.0",
         "matthiasnoback/symfony-dependency-injection-test": "0.*",
         "matthiasnoback/symfony-config-test": "0.*",
-        "doctrine/phpcr-odm": "~1.2"
+        "doctrine/phpcr-odm": "^1.2"
     },
     "suggest": {
-        "doctrine/phpcr-odm": "To enable support for the PHPCR ODM documents",
+        "doctrine/phpcr-odm": "To enable support for the PHPCR ODM documents (^1.2)",
         "doctrine/phpcr-bundle": "To enable support for the PHPCR ODM documents"
     },
     "autoload": {


### PR DESCRIPTION
There was no dependency on symfony yet, which I found rather strange for a bundle. So I've added a `symfony/framework-bundle`.